### PR TITLE
Add raw feature for inserting code when we don't using a separate *.js file.

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,7 @@ from pyh import *
 page = PyH('My wonderful PyH page')
 page.addCSS('myStylesheet1.css', 'myStylesheet2.css')
 page.addJS('myJavascript1.js', 'myJavascript2.js')
+page.add_raw('script', raw='function test() {alert("this is test()");}')
 page << h1('My big title', cl='center')
 page << div(cl='myCSSclass1 myCSSclass2', id='myDiv1') << p('I love PyH!', id='myP1')
 mydiv2 = page << div(id='myDiv2')
@@ -42,6 +43,7 @@ will generate the following html
 <link href="myStylesheet2.css" type="text/css" rel="stylesheet" />
 <script src="myJavascript1.js" type="text/javascript"></script>
 <script src="myJavascript2.js" type="text/javascript"></script>
+<script type="text/javascript">function test() {alert("this is test()");}</script>
 </head>
 <body>
 <h1 class="center">My big title</h1>

--- a/pyh.py
+++ b/pyh.py
@@ -23,7 +23,12 @@ tags = ['html', 'body', 'head', 'link', 'meta', 'div', 'p', 'form', 'legend',
         'fieldset', 'a', 'title', 'body', 'head', 'title', 'script', 'br', 'table',
         'ul', 'li', 'ol']
 
-selfClose = ['input', 'img', 'link', 'br']
+selfClose = ['input', 'img', 'link', 'br', 'meta']
+
+selfDefinedAttr = {
+    'cl': 'class',
+    'httpequiv': 'http-equiv'
+}
 
 class Tag(list):
     tagname = ''
@@ -94,7 +99,8 @@ class Tag(list):
         result = ''
         for n, v in self.attributes.iteritems():
             if n != 'txt' and n != 'open' and n != 'raw':
-                if n == 'cl': n = 'class'
+                if selfDefinedAttr.has_key(n):
+                    n = selfDefinedAttr[n]
                 result += ' %s="%s"' % (n, v)
         return result
 

--- a/pyh.py
+++ b/pyh.py
@@ -37,6 +37,7 @@ class Tag(list):
             name = 'sequence'
             self.isSeq = True
         self.id = kw.get('id', name)
+        self.raw = kw.get('raw', None)
         #self.extend(arg)
         for a in arg: self.addObj(a)
 
@@ -76,6 +77,9 @@ class Tag(list):
         result = ''
         if self.tagname:
             result = '<%s%s%s>' % (self.tagname, self.renderAtt(), self.selfClose()*' /')
+            if self.tagname == 'script' and self.raw != None:
+                result += self.raw
+
         if not self.selfClose():
             for c in self:
                 if isinstance(c, Tag):
@@ -89,7 +93,7 @@ class Tag(list):
     def renderAtt(self):
         result = ''
         for n, v in self.attributes.iteritems():
-            if n != 'txt' and n != 'open':
+            if n != 'txt' and n != 'open' and n != 'raw':
                 if n == 'cl': n = 'class'
                 result += ' %s="%s"' % (n, v)
         return result
@@ -128,6 +132,11 @@ class PyH(Tag):
             id=self.setID(obj)
             setattr(self, id, obj)
         return self
+
+    def add_raw(self, type, raw):
+        # TODO: need support raw css?
+        if type == 'script':
+            self.head += script(type='text/javascript', raw=raw)
 
     def addJS(self, *arg):
         for f in arg: self.head += script(type='text/javascript', src=f)


### PR DESCRIPTION
### Add raw feature for inserting code when we don't using a separate *.js file.

How to:
page.**add_raw**('script', raw='function test() {alert("this is test()");}')

Will get:
    < script type="text/javascript">function test() {alert("this is test()");}< /script >
